### PR TITLE
Porting from py2 to py3

### DIFF
--- a/objects/Payload.py
+++ b/objects/Payload.py
@@ -101,7 +101,7 @@ class Payload(object):
         
         if not iov:
              sortedbeamspots = OrderedDict((key, beamspots[key]) for key in sorted(list(beamspots)))
-         else:
+        else:
              sortedbeamspots = beamspots
 
         if fromDB:

--- a/objects/Payload.py
+++ b/objects/Payload.py
@@ -99,7 +99,10 @@ class Payload(object):
                     toadd = OrderedDict({ bs.Run : OrderedDict({lsrange : bs}) })
                     beamspots.update( toadd )
         
-        sortedbeamspots = OrderedDict((key, beamspots[key]) for key in sorted(beamspots.keys()))
+        if not iov:
+             sortedbeamspots = OrderedDict((key, beamspots[key]) for key in sorted(list(beamspots)))
+         else:
+             sortedbeamspots = beamspots
 
         if fromDB:
             for run, bss in sortedbeamspots.items():
@@ -385,11 +388,3 @@ if __name__ == '__main__':
         h1.Draw()
         h2.Draw('SAME')
         ROOT.gPad.SaveAs(h1.GetName() + '.pdf')
-
-
-
-
-
-
-
-

--- a/plot/plotRehauling.py
+++ b/plot/plotRehauling.py
@@ -20,15 +20,15 @@ ROOT.gStyle.SetLabelSize(0.15, 'Y')
 ROOT.gStyle.SetLabelSize(0.35, 'X')
 ROOT.gStyle.SetNdivisions(510, 'YZ')
 ROOT.gStyle.SetNdivisions(10, 'X')
-# ROOT.gStyle.SetPadGridX(True)
 ROOT.gStyle.SetPadGridY(True)
-# ROOT.gStyle.SetGridWidth(1)
 ROOT.gStyle.SetLegendFont(42)
 
-# file = ROOT.TFile.Open('/afs/cern.ch/work/m/manzoni/beamspot/2016/CMSSW_8_0_11/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/histos.root')
-# file = ROOT.TFile.Open('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2018/CMSSW_10_1_2/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/atlas_fills/histos_2018A_6638_byLS.root')
+#file = ROOT.TFile.Open('/afs/cern.ch/work/m/manzoni/beamspot/2016/CMSSW_8_0_11/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/histos.root')
+#file = ROOT.TFile.Open('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2018/CMSSW_10_1_2/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/atlas_fills/histos_2018A_6638_byLS.root')
 #file = ROOT.TFile.Open('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2018/CMSSW_10_1_2/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/forMCproduction/histos_2018A_from6688.root')
-file = ROOT.TFile.Open('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_10_6_29/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/BS_result_PiltBeam2021_byRun/histos_Express_PilotBeam2021.root')
+#file = ROOT.TFile.Open('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_10_6_29/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/BS_result_PiltBeam2021_byRun/histos_Express_PilotBeam2021.root')
+#file = ROOT.TFile.Open('/afs/cern.ch/work/d/dzuolo/private/BeamSpot/CMSSW_12_0_3_patch1/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/histos_PilotBeam2021_ExpressPhysics_FEVT.root')
+file = ROOT.TFile.Open('/afs/cern.ch/work/d/dzuolo/private/BeamSpot/CMSSW_12_0_3_patch1/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/pilotBeams2021_FEVT_LegacyBS_v1/pilotBeams2021_FEVT_LegacyBS_v1.root')
 
 file.cd()
 
@@ -41,6 +41,7 @@ beamWidthY = file.Get('beamWidthY')
 dxdz       = file.Get('dxdz'      )
 dydz       = file.Get('dydz'      )
 
+## Ranges set for 2021 pilot beam test
 variables = [
     (X         , 'beam spot x [cm]'         ,  0.15  , 0.19  ),
     (Y         , 'beam spot y [cm]'         , -0.21  ,-0.175 ),
@@ -56,7 +57,6 @@ def drawMyStyle(histo, options = '', title = '', byFill = True, byTime = False):
     
     histo.SetLineColor(ROOT.kGray)
     histo.SetLineWidth(1)
-#     histo.SetLineStyle(3)
 
     histo.GetYaxis().SetTitle(var[1])
     histo.GetXaxis().SetTitle('')
@@ -127,7 +127,6 @@ def saveHisto(var):
                          'f1', 520)
     labels.SetLabelSize(0)
     labels.Draw()
-
     
     CMS_lumi(ROOT.gPad, 5, 0)
     ROOT.gPad.Update()
@@ -137,10 +136,8 @@ def saveHisto(var):
     leg.SetLineColor(10)
     if histo3p8T .GetEntries()>0: leg.AddEntry(cloneHisto3p8T , 'B = 3.8 T' , 'EP')
 
-    ROOT.gPad.Print('BS_plot_full_by_time_PilotBeam2021_%s.pdf' %histo.GetName())
+    ROOT.gPad.Print('BSFit_pilotBeams2021_FEVT_LegacyBS_v1/%s.pdf' %histo.GetName())
 
 c1 = ROOT.TCanvas('c1', 'c1', 3000, 1000)
 for var in variables:
     saveHisto(var)
-
-

--- a/test/LHC_ring_floating/position_vs_time_run1.py
+++ b/test/LHC_ring_floating/position_vs_time_run1.py
@@ -24,7 +24,7 @@ print ('... payloads loaded')
 allBS = myPayload.fromTextToBS() 
 
 for irun, ivalues in allBS.items():
-    allBS[irun] = cleanAndSort(ivalues)
+    allBS[irun] = cleanAndSort(ivalues, cleanBadFits = True, iov = True)
 
 bs_by_run = []
 
@@ -80,7 +80,7 @@ for ibs in bs_by_run:
     month = imonth
 
 outfile = open('run1_bs_xy_vs_month.csv', 'w+')
-print >> outfile, 'year,month,x,xerr,y,yerr'
+print ('year,month,x,xerr,y,yerr', file=outfile)
 
 for ibs in newbs:
     date_start = datetime.utcfromtimestamp(ibs.IOVBeginTime)
@@ -90,12 +90,7 @@ for ibs in newbs:
           .format(date_start.year, date_start.month,
                   ibs.X          , ibs.Xerr        ,
                   ibs.Y          , ibs.Yerr        ,))
-    print >> outfile, ','.join([str(date_start.year), 
-                                str(date_start.month), 
-                                str(ibs.X), 
-                                str(ibs.Xerr), 
-                                str(ibs.Y), 
-                                str(ibs.Yerr)])     
+    print (','.join([str(date_start.year), str(date_start.month), str(ibs.X), str(ibs.Xerr), str(ibs.Y), str(ibs.Yerr)]),file=outfile)
  
 outfile.close()
 

--- a/test/LHC_ring_floating/position_vs_time_run2.py
+++ b/test/LHC_ring_floating/position_vs_time_run2.py
@@ -45,7 +45,7 @@ print ('... payloads loaded')
 allBS = myPayload.fromTextToBS() 
 
 for irun, ivalues in allBS.items():
-    allBS[irun] = cleanAndSort(ivalues)
+    allBS[irun] = cleanAndSort(ivalues, cleanBadFits = True, iov = True)
 
 
 bs_by_run = []
@@ -89,7 +89,7 @@ for ibs in bs_by_run:
     month = imonth
 
 outfile = open('run2_bs_xy_vs_month_redo.csv', 'w+')
-print >> outfile, 'year,month,x,xerr,y,yerr'
+print ('year,month,x,xerr,y,yerr', file=outfile)
 
 for ibs in newbs:
     date_start = datetime.utcfromtimestamp(ibs.IOVBeginTime)
@@ -99,12 +99,7 @@ for ibs in newbs:
           .format(date_start.year, date_start.month,
                   ibs.X          , ibs.Xerr        ,
                   ibs.Y          , ibs.Yerr        ,))
-    print >> outfile, ','.join([str(date_start.year), 
-                                str(date_start.month), 
-                                str(ibs.X), 
-                                str(ibs.Xerr), 
-                                str(ibs.Y), 
-                                str(ibs.Yerr)])     
+    print (','.join([str(date_start.year), str(date_start.month), str(ibs.X), str(ibs.Xerr), str(ibs.Y), str(ibs.Yerr)]),file=outfile)
  
 outfile.close()
 

--- a/test/LHC_ring_floating/position_vs_time_run3.py
+++ b/test/LHC_ring_floating/position_vs_time_run3.py
@@ -14,7 +14,7 @@ from utils.getFileList   import get_files
 from utils.readJson      import readJson
 
 ## 2021
-files = get_files('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_10_6_29/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/BS_result_PiltBeam2021_byFill/*.txt', prependPath=True)
+files = get_files('/afs/cern.ch/work/f/fbrivio/public/per_Davide/BS_result_PiltBeam2021_byFill/*.txt', prependPath=True)
 
 print ('start loading payloads ...')
 
@@ -25,7 +25,7 @@ print ('... payloads loaded')
 allBS = myPayload.fromTextToBS() 
 
 for irun, ivalues in allBS.items():
-    allBS[irun] = cleanAndSort(ivalues)
+    allBS[irun] = cleanAndSort(ivalues, cleanBadFits = True, iov = True)
 
 bs_by_run = []
 
@@ -64,7 +64,7 @@ for ibs in bs_by_run:
     month = imonth
 
 outfile = open('run3_bs_xy_vs_month_redo.csv', 'w+')
-print >> outfile, 'year,month,x,xerr,y,yerr'
+print ('year,month,x,xerr,y,yerr', file=outfile)
 
 for ibs in newbs:
     date_start = datetime.utcfromtimestamp(ibs.IOVBeginTime)
@@ -74,12 +74,7 @@ for ibs in newbs:
           .format(date_start.year, date_start.month,
                   ibs.X          , ibs.Xerr        ,
                   ibs.Y          , ibs.Yerr        ,))
-    print >> outfile, ','.join([str(date_start.year), 
-                                str(date_start.month), 
-                                str(ibs.X), 
-                                str(ibs.Xerr), 
-                                str(ibs.Y), 
-                                str(ibs.Yerr)])     
+    print (','.join([str(date_start.year), str(date_start.month), str(ibs.X), str(ibs.Xerr), str(ibs.Y), str(ibs.Yerr)]),file=outfile)
  
 outfile.close()
 

--- a/test/compareBS_Online_reco.py
+++ b/test/compareBS_Online_reco.py
@@ -70,15 +70,15 @@ variables = list(variables)
 # Online workflow name
 #  OnlineLegacy  : reference_BeamSpotOnlineLegacy.txt
 #  OnlineHLT     : reference_BeamSpotOnlineHLT.txt
-nameWF = 'HLT'
+nameWF = 'Legacy'
 
 if doFromScratch:
 
   # Reco files
-  r_files = get_files('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_12_0_3_patch1/src/RecoVertex/BeamSpotProducer/test/BSfitLocal/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
+  r_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
 
   # Online files
-  p_files = get_files('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_12_0_3_patch1/src/CondTools/BeamSpot/test/txts/reference_BeamSpotOnline'+nameWF+'.txt', prependPath=True)
+  p_files = get_files('/afs/cern.ch/work/f/fbrivio/public/per_Davide/PilotBeamBStxt/reference_BeamSpotOnline'+nameWF+'.txt', prependPath=True)
  
   print ('start loading payloads ...')
   onlinePayload  = Payload(p_files)
@@ -154,9 +154,9 @@ if doFromScratch:
     runsLumisOnlineCleaned.append(newOnlineBS[irun].keys())
     runsLumisRecoCleaned  .append(newRecoBS[irun].keys())
 
-    for ilumi in runsLumisRecoCleaned[i]:
+    for ilumi in list(runsLumisRecoCleaned[i]):
       if ilumi not in runsLumisOnlineCleaned[i]:  del newRecoBS[irun][ilumi]
-    for ilumi in runsLumisOnlineCleaned[i]:
+    for ilumi in list(runsLumisOnlineCleaned[i]):
       if ilumi not in runsLumisRecoCleaned[i]:  del newOnlineBS[irun][ilumi]
 
   # dump the list into a txt file, and save histos into root files

--- a/test/compareBS_Online_reco.py
+++ b/test/compareBS_Online_reco.py
@@ -10,7 +10,6 @@ from utils.compareLists  import compareLists
 from utils.fillRunDict   import labelByTime, labelByFill, splitByMagneticField
 
 ROOT.gROOT.SetBatch(True)
-# ROOT.gROOT.Reset()
 ROOT.gROOT.SetStyle('Plain')
 ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPadLeftMargin(0.1)
@@ -37,7 +36,7 @@ doFromScratch   = True
 def _doMerge( bscollection, outfilename ):
   for irun, ibs in bscollection.items():
     if irun not in specialRuns:
-      pairs = splitByDrift(ibs, slopes = True)
+      pairs = splitByDrift(ibs, slopes = True, maxLumi = 20)
     else:
       pairs = splitByDrift(ibs, slopes = True, maxLumi = 1)
     for p in pairs:
@@ -53,7 +52,8 @@ def _doSaveHistos( histolist, outfilename ):
     histo.Write()
   outfile.Close()
 
-# # Plot fit results from txt file
+## Plot fit results from txt file
+## Ranges set for 2021 pilot beam test
 variables = [
     ('X'         , 'beam spot x [cm]'         ,  0.15  , 0.19  ),
     ('Y'         , 'beam spot y [cm]'         , -0.21  ,-0.175 ),
@@ -66,16 +66,16 @@ variables = [
 ]
 variables = list(variables)
 
-
 # Online workflow name
 #  OnlineLegacy  : reference_BeamSpotOnlineLegacy.txt
 #  OnlineHLT     : reference_BeamSpotOnlineHLT.txt
-nameWF = 'Legacy'
+nameWF = 'HLT'
 
 if doFromScratch:
 
   # Reco files
-  r_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
+  #r_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
+  r_files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/2021/ExpressPhysics/crab_pilotBeams2021_FEVT_LegacyBS_v1/211124_162035/0000/BeamFit_LumiBased_pilotBeams2021_FEVT_ExpressPhysics_LegacyBS_v1_*.txt', prependPath=True)
 
   # Online files
   p_files = get_files('/afs/cern.ch/work/f/fbrivio/public/per_Davide/PilotBeamBStxt/reference_BeamSpotOnline'+nameWF+'.txt', prependPath=True)
@@ -142,10 +142,6 @@ if doFromScratch:
     n_ok_fits_reco  = float (len(newRecoBS[irun]))
     print ('fit failures in reco for run', irun, ':',   1. - n_ok_fits_reco/n_all_fits_reco)
 
-  #print '--- Job Report ---'
-  #print 'fit failures in online :', 1. - n_ok_fits_online/n_all_fits_online
-  #print 'fit failures in reco:', 1. - n_ok_fits_reco/n_all_fits_reco
-
   # now check if the remaining BSs are there in both collections and delete sinlgetons
   runsLumisOnlineCleaned = []
   runsLumisRecoCleaned = []
@@ -178,7 +174,6 @@ if doFromScratch:
   
   _doSaveHistos( p_histos, 'BS_comparison_Online/histos_online_' + nameWF + '.root' )
   _doSaveHistos( r_histos, 'BS_comparison_Online/histos_reco_'   + nameWF + '.root'   )
-
 
 histo_file_p = ROOT.TFile.Open('BS_comparison_Online/histos_online_' + nameWF + '.root', 'read')
 histo_file_r = ROOT.TFile.Open('BS_comparison_Online/histos_reco_'   + nameWF + '.root', 'read')
@@ -217,12 +212,11 @@ for ivar in variables:
   leg = ROOT.TLegend( 0.902, 0.6, 1.0, 0.75 )
   leg.SetFillColor(0)
   leg.SetLineColor(0)
-  leg.AddEntry(h_p, 'Online '+nameWF    , 'pel')
+  leg.AddEntry(h_p, 'Online '+nameWF , 'pel')
   leg.AddEntry(h_r, 'Offline Re-Reco', 'pel')
   leg.SetTextSize(0.03)
   leg.Draw('SAME')
   
   can.Update()
   can.Modified()
-  can.SaveAs('BS_comparison_Online/'+nameWF + '_BS_' + ivar[0] + '.pdf')
-
+  can.SaveAs('BS_comparison_Online/'+ nameWF + '_BS_' + ivar[0] + '.pdf')

--- a/test/compareBS_PCL_reco.py
+++ b/test/compareBS_PCL_reco.py
@@ -72,15 +72,15 @@ variables = list(variables)
 #  HPBS_byRun      : reference_PCL_HPBS_byRun.txt       ----> Express and HLT GT
 #  LegacyBS_byLumi : reference_PCL_LegacyBS_byLumi.txt  ----> Legacy
 #  LegacyBS_byRun  : reference_PCL_LegacyBS_byRun.txt   ----> Legacy
-nameWF = 'LegacyBS_byRun'
+nameWF = 'HPBS_byLumi'
 
 if doFromScratch:
 
   # Reco files
-  r_files = get_files('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_12_0_3_patch1/src/RecoVertex/BeamSpotProducer/test/BSfitLocal/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
+  r_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
 
   # PCL files
-  p_files = get_files('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_12_0_3_patch1/src/CondTools/BeamSpot/test/txts/reference_PCL_'+nameWF+'.txt', prependPath=True)
+  p_files = get_files('/afs/cern.ch/work/f/fbrivio/public/per_Davide/PilotBeamBStxt/reference_PCL_'+nameWF+'.txt', prependPath=True)
  
   print ('start loading payloads ...')
   pclPayload  = Payload(p_files)
@@ -156,9 +156,9 @@ if doFromScratch:
     runsLumisPclCleaned .append(newPclBS[irun].keys())
     runsLumisRecoCleaned.append(newRecoBS[irun].keys())
 
-    for ilumi in runsLumisRecoCleaned[i]:
+    for ilumi in list(runsLumisRecoCleaned[i]):
       if ilumi not in runsLumisPclCleaned[i]:  del newRecoBS[irun][ilumi]
-    for ilumi in runsLumisPclCleaned[i]:
+    for ilumi in list(runsLumisPclCleaned[i]):
       if ilumi not in runsLumisRecoCleaned[i]:  del newPclBS[irun][ilumi]
 
   # dump the list into a txt file, and save histos into root files

--- a/test/compareBS_PCL_reco.py
+++ b/test/compareBS_PCL_reco.py
@@ -10,7 +10,6 @@ from utils.compareLists  import compareLists
 from utils.fillRunDict   import labelByTime, labelByFill, splitByMagneticField
 
 ROOT.gROOT.SetBatch(True)
-# ROOT.gROOT.Reset()
 ROOT.gROOT.SetStyle('Plain')
 ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPadLeftMargin(0.1)
@@ -37,7 +36,7 @@ doFromScratch   = True
 def _doMerge( bscollection, outfilename ):
   for irun, ibs in bscollection.items():
     if irun not in specialRuns:
-      pairs = splitByDrift(ibs, slopes = True)
+      pairs = splitByDrift(ibs, slopes = True, maxLumi = 20)
     else:
       pairs = splitByDrift(ibs, slopes = True, maxLumi = 1)
     for p in pairs:
@@ -53,7 +52,8 @@ def _doSaveHistos( histolist, outfilename ):
     histo.Write()
   outfile.Close()
 
-# # Plot fit results from txt file
+## Plot fit results from txt file
+## Ranges set for 2021 pilot beam test
 variables = [
     ('X'         , 'beam spot x [cm]'         ,  0.15  , 0.19  ),
     ('Y'         , 'beam spot y [cm]'         , -0.21  ,-0.175 ),
@@ -66,18 +66,18 @@ variables = [
 ]
 variables = list(variables)
 
-
 # PCL workflow name
 #  HPBS_byLumi     : reference_PCL_HPBS_byLumi.txt      ----> Prompt GT
 #  HPBS_byRun      : reference_PCL_HPBS_byRun.txt       ----> Express and HLT GT
 #  LegacyBS_byLumi : reference_PCL_LegacyBS_byLumi.txt  ----> Legacy
 #  LegacyBS_byRun  : reference_PCL_LegacyBS_byRun.txt   ----> Legacy
-nameWF = 'HPBS_byLumi'
+nameWF = 'LegacyBS_byLumi'
 
 if doFromScratch:
 
   # Reco files
-  r_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
+  #r_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt', prependPath=True)
+  r_files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/2021/ExpressPhysics/crab_pilotBeams2021_FEVT_LegacyBS_v1/211124_162035/0000/BeamFit_LumiBased_pilotBeams2021_FEVT_ExpressPhysics_LegacyBS_v1_*.txt', prependPath=True)
 
   # PCL files
   p_files = get_files('/afs/cern.ch/work/f/fbrivio/public/per_Davide/PilotBeamBStxt/reference_PCL_'+nameWF+'.txt', prependPath=True)
@@ -144,10 +144,6 @@ if doFromScratch:
     n_ok_fits_reco  = float (len(newRecoBS[irun]))
     print ('fit failures in reco for run', irun, ':',   1. - n_ok_fits_reco/n_all_fits_reco)
 
-  #print '--- Job Report ---'
-  #print 'fit failures in pcl :', 1. - n_ok_fits_pcl/n_all_fits_pcl
-  #print 'fit failures in reco:', 1. - n_ok_fits_reco/n_all_fits_reco
-
   # now check if the remaining BSs are there in both collections and delete sinlgetons
   runsLumisPclCleaned  = []
   runsLumisRecoCleaned = []
@@ -180,7 +176,6 @@ if doFromScratch:
   
   _doSaveHistos( p_histos, 'BS_comparison_PCL/histos_pcl_' + nameWF + '.root' )
   _doSaveHistos( r_histos, 'BS_comparison_PCL/histos_reco_' + nameWF + '.root'   )
-
 
 histo_file_p = ROOT.TFile.Open('BS_comparison_PCL/histos_pcl_'  + nameWF + '.root', 'read')
 histo_file_r = ROOT.TFile.Open('BS_comparison_PCL/histos_reco_' + nameWF + '.root', 'read')
@@ -226,5 +221,4 @@ for ivar in variables:
   
   can.Update()
   can.Modified()
-  can.SaveAs('BS_comparison_PCL/'+nameWF + '_BS_' + ivar[0] + '.pdf')
-
+  can.SaveAs('BS_comparison_PCL/'+ nameWF + '_BS_' + ivar[0] + '.pdf')

--- a/test/compareBS_fromTxt_fromDB.py
+++ b/test/compareBS_fromTxt_fromDB.py
@@ -3,7 +3,7 @@ import ROOT
 from objects.Payload   import Payload
 from objects.BeamSpot  import *
 from utils.fillRunDict import labelByTime, labelByFill
-from utils.getFileList   import get_files
+from utils.getFileList import get_files
    
 ROOT.gROOT.SetBatch(True)
 
@@ -43,19 +43,33 @@ def drawMyStyle(histo, var, options = '', title = '', byFill = True, byTime = Fa
     return histo
    
    
-file_TXT = ['/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/IOVforPayloads/2017F/bs_ZB_2017_%d.txt' %i for i in range(1601)]
-# file obtained by running the CondTools/BeamSpot package:
-file_DB  = '/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/CondTools/BeamSpot/test/2017F_ReRecoNov.txt'
+#file_TXT = ['/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/IOVforPayloads/2017F/bs_ZB_2017_%d.txt' %i for i in range(1601)]
+file_TXT = '/afs/cern.ch/work/d/dzuolo/private/BeamSpot/CMSSW_12_0_3_patch1/src/RecoVertex/BeamSpotProducer/python/BeamspotTools/test/pilotBeams2021_FEVT_LegacyBS_v1/pilotBeams2021_FEVT_LegacyBS_v1.txt'
 
+# file obtained by running the CondTools/BeamSpot package:
+#file_DB  = '/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/CondTools/BeamSpot/test/2017F_ReRecoNov.txt'
+file_DB  = '/afs/cern.ch/work/d/dzuolo/private/BeamSpot/CMSSW_12_0_3_patch1/src/CondTools/BeamSpot/test/reference_2021_PilotBeams_LegacyBS_v2.txt'
+
+#variables = [
+#    ('X'         , 'beam spot x [cm]'         ,  0.075  , 0.095  ),
+#    ('Y'         , 'beam spot y [cm]'         , -0.04   , -0.02  ),
+#    ('Z'         , 'beam spot z [cm]'         , -6.    , 6.    ),
+#    ('sigmaZ'    , 'beam spot #sigma_{z} [cm]',  2.5    , 5.    ),
+#    ('beamWidthX', 'beam spot #sigma_{x} [cm]',  0.E-3 , 4E-3 ),
+#    ('beamWidthY', 'beam spot #sigma_{y} [cm]',  0.E-3 , 4E-3 ),
+#    ('dxdz'      , 'beam spot dx/dz [rad]'    , -.1e-3 , .8e-3 ),
+#    ('dydz'      , 'beam spot dy/dz [rad]'    , -6.e-4 , .8e-3 ),
+#]
+## Ranges set for 2021 pilot beam test
 variables = [
-    ('X'         , 'beam spot x [cm]'         ,  0.075  , 0.095  ),
-    ('Y'         , 'beam spot y [cm]'         , -0.04   , -0.02  ),
-    ('Z'         , 'beam spot z [cm]'         , -6.    , 6.    ),
-    ('sigmaZ'    , 'beam spot #sigma_{z} [cm]',  2.5    , 5.    ),
-    ('beamWidthX', 'beam spot #sigma_{x} [cm]',  0.E-3 , 4E-3 ),
-    ('beamWidthY', 'beam spot #sigma_{y} [cm]',  0.E-3 , 4E-3 ),
-    ('dxdz'      , 'beam spot dx/dz [rad]'    , -.1e-3 , .8e-3 ),
-    ('dydz'      , 'beam spot dy/dz [rad]'    , -6.e-4 , .8e-3 ),
+    ('X'         , 'beam spot x [cm]'         ,  0.15  , 0.19  ),
+    ('Y'         , 'beam spot y [cm]'         , -0.21  ,-0.175 ),
+    ('Z'         , 'beam spot z [cm]'         , -3.    , 3     ),
+    ('sigmaZ'    , 'beam spot #sigma_{z} [cm]',  3.5   , 9.    ),
+    ('beamWidthX', 'beam spot #sigma_{x} [cm]',  0.00  , 0.025 ),
+    ('beamWidthY', 'beam spot #sigma_{y} [cm]',  0.00  , 0.025 ),
+    ('dxdz'      , 'beam spot dx/dz [rad]'    , -0.002 , 0.002 ),
+    ('dydz'      , 'beam spot dy/dz [rad]'    , -0.002 , 0.002 ),
 ]
 
 myPL_TXT = Payload(file_TXT)
@@ -86,5 +100,5 @@ for i, histos in enumerate(zip(histosTXT, histosDB)):
     leg.Draw('same')
     
     ROOT.gPad.Update()
-    ROOT.gPad.Print('BS_comparison_plot_' + histos[0].GetName() + '_2017F.pdf')
+    ROOT.gPad.Print('BS_txt_db_comparison/' + histos[0].GetName() + '.pdf')
 

--- a/test/compareBS_prompt_reco.py
+++ b/test/compareBS_prompt_reco.py
@@ -9,7 +9,6 @@ from utils.compareLists  import compareLists
 from utils.fillRunDict   import labelByTime, labelByFill, splitByMagneticField
 
 ROOT.gROOT.SetBatch(True)
-# ROOT.gROOT.Reset()
 ROOT.gROOT.SetStyle('Plain')
 ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPadLeftMargin(0.1)
@@ -33,11 +32,10 @@ specialRuns = [300019,300029,300043,300050]
 verbosePrinting = True
 doFromScratch   = True
 
-
 def _doMerge( bscollection, outfilename ):
   for irun, ibs in bscollection.items():
     if irun not in specialRuns:
-      pairs = splitByDrift(ibs, slopes = True)    
+      pairs = splitByDrift(ibs, slopes = True, maxLumi = 20)    
     else:
       pairs = splitByDrift(ibs, slopes = True, maxLumi = 1)    
     for p in pairs:
@@ -53,17 +51,17 @@ def _doSaveHistos( histolist, outfilename ):
     histo.Write()
   outfile.Close()
 
-
-# # Plot fit results from txt file
+## Plot fit results from txt file
+## Ranges set for 2021 pilot beam test
 variables = [
-    ('X'         , 'beam spot x [cm]'         ,  0.076  , 0.088  ),
-    ('Y'         , 'beam spot y [cm]'         , -0.036  , -0.024  ),
-    ('Z'         , 'beam spot z [cm]'         , -6.    , 6.    ),
-    ('sigmaZ'    , 'beam spot #sigma_{z} [cm]',  2.5    , 5.    ),
-    ('beamWidthX', 'beam spot #sigma_{x} [cm]',  0.E-3 , 4E-3 ),
-    ('beamWidthY', 'beam spot #sigma_{y} [cm]',  0.E-3 , 4E-3 ),
-    ('dxdz'      , 'beam spot dx/dz [rad]'    , -.1e-3 , .8e-3 ),
-    ('dydz'      , 'beam spot dy/dz [rad]'    , -6.e-4 , .8e-3 ),
+    ('X'         , 'beam spot x [cm]'         ,  0.15  , 0.19  ),
+    ('Y'         , 'beam spot y [cm]'         , -0.21  ,-0.175 ),
+    ('Z'         , 'beam spot z [cm]'         , -3.    , 3     ),
+    ('sigmaZ'    , 'beam spot #sigma_{z} [cm]',  3.5   , 9.    ),
+    ('beamWidthX', 'beam spot #sigma_{x} [cm]',  0.00  , 0.025 ),
+    ('beamWidthY', 'beam spot #sigma_{y} [cm]',  0.00  , 0.025 ),
+#    ('dxdz'      , 'beam spot dx/dz [rad]'    , -.1e-3 , .8e-3 ),
+#    ('dydz'      , 'beam spot dy/dz [rad]'    , -6.e-4 , .8e-3 ),
 ### for 2017C
 #     ('X'         , 'beam spot x [cm]'         ,  0.05  , 0.12  ),
 #     ('Y'         , 'beam spot y [cm]'         , -0.065 ,-0.005  ),
@@ -77,20 +75,7 @@ variables = [
 
 variables = list(variables)
 
-
-# variables = [
-#   'X'         ,
-#   'Y'         ,
-#   'Z'         ,
-#   'sigmaZ'    ,
-#   'dxdz'      ,
-#   'dydz'      ,
-#   'beamWidthX',
-#   'beamWidthY'
-# ]
-
-runstring = '2017H' 
-
+runstring = '2021BeamTest' 
 
 if doFromScratch:
 
@@ -138,7 +123,9 @@ if doFromScratch:
 #   r_files += get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/SeptRepro2017/crab_BS_ReproSept2017_Run2017C_v2_missingLumis/*'           , prependPath=True)
 #   r_files += get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/SeptRepro2017/crab_BS_ReproSept2017_Run2017C_v2_SpecialRuns/*'           , prependPath=True)
   
-  r_files = get_files('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/RecoVertex/BeamSpotProducer/test/split_2017H_96perc/*.txt'         , prependPath=True)
+#  r_files = get_files('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/RecoVertex/BeamSpotProducer/test/split_2017H_96perc/*.txt'         , prependPath=True)
+#  r_files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/test_2021_LHC_BeamTest_ExpressPhysics_FEVT/crab_FEVT_TkAlignment_postCRAFT_noRefit/211115_182853/0000/BeamFit_LumiBased_BeamTest2021_Refit_generalTracks_FEVT_*.txt', prependPath=True)
+  r_files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/2021/ExpressPhysics/crab_pilotBeams2021_FEVT_LegacyBS_v1/211124_162035/0000/BeamFit_LumiBased_pilotBeams2021_FEVT_ExpressPhysics_LegacyBS_v1_*.txt', prependPath=True)
   
   
 #   p_files  = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/SeptRepro2017/crab_BS_ReproSept2017_Run2017B_v1_Prompt/*'        , prependPath=True)
@@ -160,9 +147,9 @@ if doFromScratch:
 #   p_files += get_files('/eos/cms//store/group/phys_tracking/beamspot/13TeV/2017/ZeroBias/crab_BS_Prompt_Run2017F/171129_224109/0001/*'        , prependPath=True)
 
 #   p_files  = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/2017/es1p1/JetHT/crab_BS_JetHT_Prompt_Run2017F_es1p1/171205_220828/0000/*.txt'         , prependPath=True)
-  p_files = get_files('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/RecoVertex/BeamSpotProducer/test/split_2017H_prompt_96perc/*.txt'         , prependPath=True)
+#  p_files = get_files('/afs/cern.ch/work/f/fiorendi/private/BeamSpot/2017/CMSSW_9_4_0_pre3/src/RecoVertex/BeamSpotProducer/test/split_2017H_prompt_96perc/*.txt'         , prependPath=True)
+  p_files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt'         , prependPath=True)
 
- 
   print ('start loading payloads ...')
   promptPayload = Payload(p_files)
   recoPayload   = Payload(r_files)
@@ -226,10 +213,6 @@ if doFromScratch:
       n_ok_fits_reco   = float (len(newRecoBS[irun]))
       print ('fit failures in reco for run', irun, ':',   1. - n_ok_fits_reco/n_all_fits_reco)  
 
-#   print '--- Job Report ---'
-#   print 'fit failures in prompt:', 1. - n_ok_fits_prompt/n_all_fits_prompt  
-#   print 'fit failures in reco:',   1. - n_ok_fits_reco/n_all_fits_reco  
-      
   # now check if the remaining BSs are there in both collections and delete sinlgetons
   runsLumisPromptCleaned = []
   runsLumisRecoCleaned   = []
@@ -243,15 +226,12 @@ if doFromScratch:
     for ilumi in list(runsLumisPromptCleaned[i]):
       if ilumi not in runsLumisRecoCleaned[i]:  del newPromptBS[irun][ilumi]
   
-  
   # dump the list into a txt file, and save histos into root files
-  promptname = 'prompt_payloads' + runstring + '.txt'
-  reconame   = 'reco_payloads' + runstring + '.txt'
+  promptname = 'BS_comparison_prompt/prompt_payloads' + runstring + '.txt'
+  reconame   = 'BS_comparison_prompt/reco_payloads' + runstring + '.txt'
   
   _doMerge(newPromptBS, promptname)
   _doMerge(newRecoBS  , reconame  )
-  
- 
   
   merged_payload_p = Payload(promptname)
   merged_payload_r = Payload(reconame)
@@ -263,14 +243,11 @@ if doFromScratch:
       p_histos.append(merged_payload_p.plot(ivar[0] , -999999, 999999, savePdf = False, dilated = 5, byFill = False, returnHisto = True))
       r_histos.append(merged_payload_r.plot(ivar[0] , -999999, 999999, savePdf = False, dilated = 5, byFill = False, returnHisto = True))
   
-  _doSaveHistos( p_histos, 'histos_prompt' + runstring + '.root' )
-  _doSaveHistos( r_histos, 'histos_reco' + runstring + '.root'   )
-  
-  
+  _doSaveHistos( p_histos, 'BS_comparison_prompt/histos_prompt' + runstring + '.root' )
+  _doSaveHistos( r_histos, 'BS_comparison_prompt/histos_reco' + runstring + '.root'   )
 
-histo_file_p = ROOT.TFile.Open('histos_prompt' + runstring + '.root', 'read')
-histo_file_r = ROOT.TFile.Open('histos_reco' + runstring + '.root'  , 'read')
-
+histo_file_p = ROOT.TFile.Open('BS_comparison_prompt/histos_prompt' + runstring + '.root', 'read')
+histo_file_r = ROOT.TFile.Open('BS_comparison_prompt/histos_reco' + runstring + '.root'  , 'read')
 
 for ivar in variables: 
   print (ivar)
@@ -302,7 +279,6 @@ for ivar in variables:
   if runstring == '2017C' and 'Width' in ivar[0]:
     h_p.GetYaxis().SetRangeUser(ivar[2], 9E-3)
 
-
   h_r = histo_file_r.Get(ivar[0])
   h_r.SetMarkerSize(0.2)
   h_r.SetMarkerColor(2)
@@ -312,12 +288,12 @@ for ivar in variables:
   leg = ROOT.TLegend( 0.902, 0.6, 1.0, 0.75 )
   leg.SetFillColor(0)
   leg.SetLineColor(0)
-  leg.AddEntry(h_p   , 'Prompt'   , 'pel')
-  leg.AddEntry(h_r   , 'ReReco'    , 'pel')
+  leg.AddEntry(h_p, 'v0_StreamExpress_ALCARECO', 'pel')
+  leg.AddEntry(h_r, 'v1_ExpressPhysics_FEVT'   , 'pel')
   leg.SetTextSize(0.03)
   leg.Draw('SAME')
   
   can.Update()
   can.Modified()
-  can.SaveAs('comparePromptReco_ZB_RunH/' + runstring + '/'+ivar[0] + '_Prompt_vs_NovReco_' + runstring + '.pdf')
+  can.SaveAs('BS_comparison_prompt/' + runstring + '_BS_' + ivar[0] + '_v0-StreamExpressALCARECO_vs_v1-ExpressPhysics-FEVT' + '.pdf')
 

--- a/test/compareBS_prompt_reco.py
+++ b/test/compareBS_prompt_reco.py
@@ -238,9 +238,9 @@ if doFromScratch:
     runsLumisPromptCleaned.append( newPromptBS[irun].keys())
     runsLumisRecoCleaned  .append( newRecoBS[irun].keys())
     
-    for ilumi in runsLumisRecoCleaned[i]:
+    for ilumi in list(runsLumisRecoCleaned[i]):
       if ilumi not in runsLumisPromptCleaned[i]:  del newRecoBS[irun][ilumi]
-    for ilumi in runsLumisPromptCleaned[i]:
+    for ilumi in list(runsLumisPromptCleaned[i]):
       if ilumi not in runsLumisRecoCleaned[i]:  del newPromptBS[irun][ilumi]
   
   

--- a/test/test_workflow_Run2016B.py
+++ b/test/test_workflow_Run2016B.py
@@ -69,13 +69,15 @@ fname = 'pilotBeams2021_FEVT_LegacyBS_v1.txt'
 count = 0
 for irun, ibs in allBS.items():
     if irun not in specialRuns:
-      pairs = splitByDrift(ibs, slopes = True, maxLumi = 20)    
-    else:
       pairs = splitByDrift(ibs, slopes = True)    
+    else:
+      pairs = splitByDrift(ibs, slopes = True, maxLumi = 1)    
     for p in pairs:
         myrange = set(range(p[0], p[1] + 1)) & set(ibs.keys())
         bs_list = [ibs[i] for i in sorted(list(myrange))]
         aveBeamSpot = averageBeamSpot(bs_list)
+## Create a txt file for each IOV for db object creation
+#        fname = filename.replace('_.txt', '_'+str(count)+'.txt')
         aveBeamSpot.Dump(fname, 'a+')
         count = count + 1
 

--- a/test/test_workflow_Run2016B.py
+++ b/test/test_workflow_Run2016B.py
@@ -66,6 +66,8 @@ fname = 'pilotBeams2021_FEVT_LegacyBS_v1.txt'
 #         os.remove(fname)
 
 # check drifts and create IOV
+## filename for txt files containing one IOV
+#filename = 'BS_result_PiltBeam2021_byIOV/beamspot_Express_PilotBeam2021_.txt'
 count = 0
 for irun, ibs in allBS.items():
     if irun not in specialRuns:

--- a/test/test_workflow_Run2016B.py
+++ b/test/test_workflow_Run2016B.py
@@ -29,7 +29,10 @@ XeXeRuns = [304899,304906]
 #files = get_files('/eos/cms//store/group/phys_tracking/beamspot/13TeV/2017/es0p9/HighEGJet/crab_BS_JetHT_Prompt_Run2017G_es0p9/180220_211350/0000/*.txt' , prependPath=True)
 
 ###Run2021 PilotBeam Express
-files = get_files('/afs/cern.ch/work/f/fbrivio/beamSpot/2021/PilotBeam2021/CMSSW_12_0_3_patch1/src/RecoVertex/BeamSpotProducer/test/BSfitLocal/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt' , prependPath=True)
+#files = get_files('/afs/cern.ch/work/f/fbrivio/public/BeamSpot/perDavide/BeamFit_LumiBased_NewAlignWorkflow_alcareco_Fill*.txt' , prependPath=True)
+#files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/StreamExpress/crab_test/211111_155451/0000/BeamFit_LumiBased_NewAlignWorkflow_BeamTest2021*.txt' , prependPath=True)
+#files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/test_2021_LHC_BeamTest_ExpressPhysics_FEVT/crab_FEVT_TkAlignment_postCRAFT_noRefit/211115_182853/0000/BeamFit_LumiBased_BeamTest2021_Refit_generalTracks_FEVT_*.txt' , prependPath=True)
+files = get_files('/eos/cms/store/group/phys_tracking/beamspot/13TeV/2021/ExpressPhysics/crab_pilotBeams2021_FEVT_LegacyBS_v1/211124_162035/0000/BeamFit_LumiBased_pilotBeams2021_FEVT_ExpressPhysics_LegacyBS_v1_*.txt' , prependPath=True)
 
 print ('start loading payloads ...')
 myPayload = Payload(files)
@@ -48,7 +51,7 @@ for irun, ivalues in allBS.items():
         print ("WARNING: more than 10% of the fits failed for run", irun)
 
 # check if output file exists
-fname = 'beamspot_Express_PilotBeam2021.txt'
+fname = 'pilotBeams2021_FEVT_LegacyBS_v1.txt'
 # if os.path.isfile(fname):
 #     print 'File %s exists. Recreate? (10 sec before defaults to True)' %fname
 #     i, o, e = select.select( [sys.stdin], [], [], 10 )
@@ -63,21 +66,18 @@ fname = 'beamspot_Express_PilotBeam2021.txt'
 #         os.remove(fname)
 
 # check drifts and create IOV
-#filename = 'BS_result_PiltBeam2021_byIOV/beamspot_Express_PilotBeam2021_.txt'
 count = 0
 for irun, ibs in allBS.items():
     if irun not in specialRuns:
-      pairs = splitByDrift(ibs, slopes = True)    
+      pairs = splitByDrift(ibs, slopes = True, maxLumi = 20)    
     else:
-      pairs = splitByDrift(ibs, slopes = True, maxLumi = 1)    
+      pairs = splitByDrift(ibs, slopes = True)    
     for p in pairs:
         myrange = set(range(p[0], p[1] + 1)) & set(ibs.keys())
         bs_list = [ibs[i] for i in sorted(list(myrange))]
         aveBeamSpot = averageBeamSpot(bs_list)
-#        fname = filename.replace('_.txt', '_'+str(count)+'.txt')
         aveBeamSpot.Dump(fname, 'a+')
         count = count + 1
-
 
 merged_payload = Payload(fname)
 histos = []
@@ -97,17 +97,9 @@ variables = [
 for ivar in variables: 
     histos.append(merged_payload.plot(ivar , -999999, 999999, savePdf = True, dilated = 4, byFill = False, returnHisto = True))
 
-histo_file = ROOT.TFile.Open('histos_Express_PilotBeam2021.root', 'recreate')
-#histo_file = ROOT.TFile.Open('BS_result_PiltBeam2021_byIOV/histos_Express_PilotBeam2021.root', 'recreate')
+histo_file = ROOT.TFile.Open('pilotBeams2021_FEVT_LegacyBS_v1.root', 'recreate')
 histo_file.cd()
 for histo in histos:
     histo.Write()
 
 histo_file.Close()
-
-
-
-
-
-
-

--- a/utils/beamSpotMerge.py
+++ b/utils/beamSpotMerge.py
@@ -15,8 +15,8 @@ def cleanAndSort(fullList, cleanBadFits = True, iov = False):
     '''
     # clean from badly converged
     cleaned =  {k:v for k, v in fullList.items() if v.Type > 0 and cleanBadFits}
-    if not iov:
     # sort by LS
+    if not iov:
         ordered = OrderedDict(sorted(cleaned.items(), key = lambda t: t[0]))
     else:
         ordered = cleaned

--- a/utils/beamSpotMerge.py
+++ b/utils/beamSpotMerge.py
@@ -67,7 +67,7 @@ def splitByDrift(fullList, maxLumi = 60, splitInfo = False, run = -1,
     # breaking points. 
     # First LS is the first starting point by definition
     if not len(fullList.keys()):  return []
-    breaks = [fullList.keys()[0]]
+    breaks = [list(fullList)[0]]
         
     # lumi counter
     i = 0
@@ -77,9 +77,9 @@ def splitByDrift(fullList, maxLumi = 60, splitInfo = False, run = -1,
     # Reset every maxLumi lumi sections or at every drift
     for j in range( 1, len(fullList.items())-1 ):
         
-        lumi        = fullList.keys()[j  ]
-        lumi_before = fullList.keys()[j-1]
-        lumi_after  = fullList.keys()[j+1]
+        lumi        = list(fullList)[j  ]
+        lumi_before = list(fullList)[j-1]
+        lumi_after  = list(fullList)[j+1]
 
         bs        = fullList[lumi       ]  # bs        is the current beam spot
         bs_before = fullList[lumi_before]  # bs_before is the previous
@@ -163,7 +163,7 @@ def splitByDrift(fullList, maxLumi = 60, splitInfo = False, run = -1,
                 break
 
     # Last LS is the first breaking point by definition
-    breaks.append(fullList.keys()[-1])
+    breaks.append(list(fullList)[-1])
 
     # sort the list. There may be repeated breaking points in case
     # one finds a lumi range of one lumi only

--- a/utils/beamSpotMerge.py
+++ b/utils/beamSpotMerge.py
@@ -8,16 +8,18 @@ import sys
 sys.path.append('..')
 from objects.BeamSpot import BeamSpot
 
-def cleanAndSort(fullList, cleanBadFits = True):
+def cleanAndSort(fullList, cleanBadFits = True, iov = False):
     '''
     Sorts the lumi:BS dictionary and cleans it up
     from the not properly converged fits.
     '''
     # clean from badly converged
     cleaned =  {k:v for k, v in fullList.items() if v.Type > 0 and cleanBadFits}
-
+    if not iov:
     # sort by LS
-    ordered = OrderedDict(sorted(cleaned.items(), key = lambda t: t[0]))
+        ordered = OrderedDict(sorted(cleaned.items(), key = lambda t: t[0]))
+    else:
+        ordered = cleaned
                                          
     return ordered
 


### PR DESCRIPTION
Changes to test/LHC_ring_floating/position_vs_time_run1.py, test/LHC_ring_floating/position_vs_time_run2.py test/LHC_ring_floating/position_vs_time_run3.py, test/compareBS_Online_reco.py, test/compareBS_PCL_reco.py 
Changes to objects/Payload.py, utilis/beamSpotMerge.py: in order to bypass the incapability of python3 to sort non-standard objects (IOVs here https://github.com/MilanoBicocca-pix/BeamspotTools/blob/5f97cd4fd284dbb053d7517f3a4b2343c35bcdea/test/test_workflow_Run2016B.py#L98 invoking https://github.com/MilanoBicocca-pix/BeamspotTools/blob/5f97cd4fd284dbb053d7517f3a4b2343c35bcdea/objects/Payload.py#L70 with iov=True and string+integers here https://github.com/MilanoBicocca-pix/BeamspotTools/blob/5f97cd4fd284dbb053d7517f3a4b2343c35bcdea/test/LHC_ring_floating/position_vs_time_run1.py#L27 invoking https://github.com/MilanoBicocca-pix/BeamspotTools/blob/5f97cd4fd284dbb053d7517f3a4b2343c35bcdea/utils/beamSpotMerge.py#L11) two methods have been modified. Actually the sorting was unnecessary in both cases because the Payload and dictionary invoking methods are already sorted by construction.