### PR TITLE
fix python packages used in fetch_from_OMS.py

### DIFF
--- a/data/fetch_from_OMS.py
+++ b/data/fetch_from_OMS.py
@@ -26,6 +26,7 @@ def get_cookie(url):
   '''
   cookiepath = './.cookiefile_OMSfetch.txt'
   print("[INFO] generating cookie for url", url)
+  os.system('export PYTHONNOUSERSITE=1') # needed to use the system-wide packages, not the user defined ones
   cmd = 'auth-get-sso-cookie --url "{}" -o {}'.format(url, cookiepath)
   ret = os.system(cmd)
   cookie = cookielib.MozillaCookieJar(cookiepath)


### PR DESCRIPTION
In case one has some user-site packages defined in
```
$HOME/.local/lib/python3.6/site-packages
```
these user-site packages have precedence over the system-wide packages and they might break the `auth-get-sso-cookie` dependencies, generating the error:
```
ERROR: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:897)
```
The command
```
export PYTHONNOUSERSITE=1
```
fixes the issue avoiding the need to modify anything on their files/configs.