### PR TITLE
Update BeamFit_custom_workflow.py

### DIFF
--- a/test/BeamFit_custom_workflow.py
+++ b/test/BeamFit_custom_workflow.py
@@ -162,8 +162,8 @@ process.d0_phi_analyzer.PVFitter.minNrVerticesForFit         = 10
 process.d0_phi_analyzer.PVFitter.nSigmaCut                   = 50.0
 process.d0_phi_analyzer.PVFitter.VertexCollection            = INPUT_PVS 
    
-process.d0_phi_analyzer.BSAnalyzerParameters.fitEveryNLumi   = 5
-process.d0_phi_analyzer.BSAnalyzerParameters.resetEveryNLumi = 5
+process.d0_phi_analyzer.BSAnalyzerParameters.fitEveryNLumi   = 1
+process.d0_phi_analyzer.BSAnalyzerParameters.resetEveryNLumi = 1
 
 if options.highPurity:
     d0_phi_analyzer_cff.PVFitter.useOnlyFirstPV     = True


### PR DESCRIPTION
don't fit every 5 lumis
It does not work because lumi sections are not necessarily stored in increasing order in the same file